### PR TITLE
Initial Implementation + some tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,13 @@ lazy val plugin = (project in file("plugin"))
     resolvers += "Typesafe Maven Repository" at "https://dl.bintray.com/typesafe/maven-releases/",
     libraryDependencies += "com.typesafe.play" %% "play" % play.core.PlayVersion.current % "provided",
     libraryDependencies += "com.typesafe.play" %% "play-cache" % play.core.PlayVersion.current % "provided",
+
     libraryDependencies += "com.typesafe.play" %% "play-test" % play.core.PlayVersion.current % "provided,test",
+    libraryDependencies += "com.typesafe.play" %% "play-specs2" % play.core.PlayVersion.current % "provided,test",
+
+    libraryDependencies += "javax.cache" % "cache-api" % "1.0.0" % "provided",
+    libraryDependencies += "org.ehcache" % "ehcache" % "3.1.2" % "provided",
+
     publishTo <<= version { v: String =>
       val nexus = "https://oss.sonatype.org/"
       if (v.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "content/repositories/snapshots")

--- a/plugin/src/main/resources/reference.conf
+++ b/plugin/src/main/resources/reference.conf
@@ -1,1 +1,20 @@
-play.modules.enabled += "org.ehcache.integrations.play.JCacheModule"
+play {
+  modules {
+    enabled += "org.ehcache.integrations.play.JCacheModule"
+  }
+
+  cache {
+    # The name of the resource that should be used to configure the cache
+    # jcacheConfig
+
+    # The caches to bind
+    bindCaches = []
+
+    # Whether play should try to create the caches listed in bindCaches
+    createBoundCaches = true
+
+    # The name of the default cache to use in ehcache
+    defaultCache = "play"
+  }
+
+}

--- a/plugin/src/main/scala/org/ehcache/integrations/play/JCacheModule.scala
+++ b/plugin/src/main/scala/org/ehcache/integrations/play/JCacheModule.scala
@@ -16,12 +16,166 @@
 
 package org.ehcache.integrations.play
 
+import javax.cache.configuration.MutableConfiguration
+import javax.inject.{Inject, Provider, Singleton}
+import javax.cache.{Cache, CacheException, CacheManager, Caching}
+
+import com.google.common.primitives.Primitives
+import play.api.cache.{CacheApi, Cached, NamedCache}
 import play.api.{Configuration, Environment}
-import play.api.inject.{Binding, Module}
+import play.api.inject._
+import play.cache.{NamedCacheImpl, CacheApi => JavaCacheApi, DefaultCacheApi => DefaultJavaCacheApi}
+
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.reflect.ClassTag
+
+/**
+  * JCache components for compile time injection
+  */
+trait JCacheComponents {
+  def environment: Environment
+
+  def configuration: Configuration
+
+  def applicationLifecycle: ApplicationLifecycle
+
+  lazy val jCacheManager: CacheManager = new CacheManagerProvider(environment, configuration, applicationLifecycle).get
+
+  /**
+    * Use this to create with the given name.
+    */
+  def cacheApi(name: String, create: Boolean = true): CacheApi = {
+    new JCacheApi(NamedJCacheProvider.getNamedCache(name, jCacheManager, create).get)
+  }
+
+  lazy val defaultCacheApi: CacheApi = cacheApi("play")
+}
 
 /**
   * JCacheModule
   */
+@Singleton
 class JCacheModule extends Module {
-  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = ???
+
+  import scala.collection.JavaConversions._
+
+  def bindings(environment: Environment, configuration: Configuration) = {
+    val defaultCacheName = configuration.getString("play.cache.defaultCache").get
+    val bindCaches = configuration.getStringList("play.cache.bindCaches").get
+    val createBoundCaches = configuration.getBoolean("play.cache.createBoundCaches").get
+
+    // Creates a named cache qualifier
+    def named(name: String): NamedCache = {
+      new NamedCacheImpl(name)
+    }
+
+    // bind a cache with the given name
+    def bindCache(name: String) = {
+      val namedCache = named(name)
+      val jcacheKey = bind[Cache[String, Any]].qualifiedWith(namedCache)
+      val cacheApiKey = bind[CacheApi].qualifiedWith(namedCache)
+      Seq(
+        jcacheKey.to(new NamedJCacheProvider(name, createBoundCaches)),
+        cacheApiKey.to(new NamedCacheApiProvider(jcacheKey)),
+        bind[JavaCacheApi].qualifiedWith(namedCache).to(new NamedJavaCacheApiProvider(cacheApiKey)),
+        bind[Cached].qualifiedWith(namedCache).to(new NamedCachedProvider(cacheApiKey))
+      )
+    }
+
+    Seq(
+      bind[CacheManager].toProvider[CacheManagerProvider],
+      // alias the default cache to the unqualified implementation
+      bind[CacheApi].to(bind[CacheApi].qualifiedWith(named(defaultCacheName))),
+      bind[JavaCacheApi].to[DefaultJavaCacheApi]
+    ) ++ bindCache(defaultCacheName) ++ bindCaches.flatMap(bindCache)
+  }
+}
+
+@Singleton
+class CacheManagerProvider @Inject()(env: Environment, config: Configuration, lifecycle: ApplicationLifecycle) extends Provider[CacheManager] {
+  lazy val get: CacheManager = {
+    val provider = Caching.getCachingProvider
+    val resourceName = config.getString("play.cache.jcacheConfig")
+    val configUri = resourceName.map(env.resource(_).get).map(_.toURI).getOrElse(provider.getDefaultURI)
+    val manager = provider.getCacheManager(configUri, env.classLoader)
+    lifecycle.addStopHook(() => Future.successful(manager.close()))
+    manager
+  }
+}
+
+private[play] class NamedJCacheProvider(name: String, create: Boolean) extends Provider[Cache[String, Any]] {
+  @Inject private var manager: CacheManager = _
+  lazy val get: Cache[String, Any] = NamedJCacheProvider.getNamedCache(name, manager, create).get
+}
+
+private[play] object NamedJCacheProvider {
+  def getNamedCache(name: String, manager: CacheManager, create: Boolean): Option[Cache[String, Any]] = {
+    Option(manager.getCache(name, classOf[String], classOf[Any]))
+      .orElse(if (create) Option(manager.createCache(name, new MutableConfiguration[String, Any]().setTypes(classOf[String], classOf[Any]))) else Option.empty)
+  }
+}
+
+private[play] class NamedCacheApiProvider(key: BindingKey[Cache[String, Any]]) extends Provider[CacheApi] {
+  @Inject private var injector: Injector = _
+  lazy val get: CacheApi = {
+    new JCacheApi(injector.instanceOf(key))
+  }
+}
+
+private[play] class NamedJavaCacheApiProvider(key: BindingKey[CacheApi]) extends Provider[JavaCacheApi] {
+  @Inject private var injector: Injector = _
+  lazy val get: JavaCacheApi = {
+    new DefaultJavaCacheApi(injector.instanceOf(key))
+  }
+}
+
+private[play] class NamedCachedProvider(key: BindingKey[CacheApi]) extends Provider[Cached] {
+  @Inject private var injector: Injector = _
+  lazy val get: Cached = {
+    new Cached(injector.instanceOf(key))
+  }
+}
+
+@Singleton
+class JCacheApi @Inject()(cache: Cache[String, Any]) extends CacheApi {
+
+  def set(key: String, value: Any, expiration: Duration) = {
+    cache.put(key, value)
+  }
+
+  def get[T: ClassTag](key: String): Option[T] = {
+    return filter(cache.get(key))
+  }
+
+  def getOrElse[A: ClassTag](key: String, expiration: Duration)(orElse: => A): A = {
+    val current = Option(cache.get(key))
+    if (current.isEmpty) {
+      if (cache.putIfAbsent(key, orElse)) {
+        orElse
+      }
+    } else {
+      val filtered = filter(current.get)
+      if (filtered.isEmpty) {
+        //this isn't right!
+        if (cache.replace(key, current.get, orElse)) {
+          orElse
+        }
+      } else {
+        filtered.get
+      }
+    }
+    getOrElse(key, expiration)(orElse)
+  }
+
+  def remove(key: String) = {
+    cache.remove(key)
+  }
+
+  private def filter[T](value: Any)(implicit ct: ClassTag[T]): Option[T] = {
+    Option(value).filter { v =>
+      Primitives.wrap(ct.runtimeClass).isInstance(v) ||
+        ct == ClassTag.Nothing || (ct == ClassTag.Unit && v == ((): Unit))
+    }.asInstanceOf[Option[T]]
+  }
 }

--- a/plugin/src/test/scala/org/ehcache/integrations/play/JCacheModuleSpec.scala
+++ b/plugin/src/test/scala/org/ehcache/integrations/play/JCacheModuleSpec.scala
@@ -1,0 +1,315 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package org.ehcache.integrations.play
+
+import java.util.concurrent.atomic.AtomicInteger
+import javax.cache.configuration.MutableConfiguration
+import javax.inject._
+
+import org.joda.time.DateTime
+import play.api.cache.{CacheApi, Cached}
+import play.api.http
+import play.api.mvc.{Action, Results}
+import play.api.test._
+import play.cache.NamedCache
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+class CachedSpec extends PlaySpecification {
+
+  sequential
+
+  val configuration = play.api.Configuration.from(Map(
+    "play.modules.disabled" -> Seq("play.api.cache.EhCacheModule"),
+    "play.modules.enabled" -> Seq("org.ehcache.integrations.play.JCacheModule", "play.api.inject.BuiltinModule")
+  ))
+
+  val modules = play.api.inject.Modules.locate(play.api.Environment.simple(), configuration)
+
+  "play-jcache" should {
+    "provide JCacheModule" in {
+      (modules.find { module => module.isInstanceOf[JCacheModule] }.isDefined)
+    }
+  }
+
+  "the cached action" should {
+    "cache values using injected CachedApi" in new WithApplication(
+        _.configure(configuration)
+    ) {
+      val controller = app.injector.instanceOf[CachedController]
+      val result1 = controller.action(FakeRequest()).run()
+      contentAsString(result1) must_== "1"
+      controller.invoked.get() must_== 1
+      val result2 = controller.action(FakeRequest()).run()
+      contentAsString(result2) must_== "1"
+      controller.invoked.get() must_== 1
+
+      // Test that the same headers are added
+      header(ETAG, result2) must_== header(ETAG, result1)
+      header(EXPIRES, result2) must_== header(EXPIRES, result1)
+    }
+
+    "cache values using named injected CachedApi" in new WithApplication(
+      _.configure(configuration).configure("play.cache.bindCaches" -> Seq("custom"))
+    ) {
+      val controller = app.injector.instanceOf[NamedCachedController]
+      val result1 = controller.action(FakeRequest()).run()
+      contentAsString(result1) must_== "1"
+      controller.invoked.get() must_== 1
+      val result2 = controller.action(FakeRequest()).run()
+      contentAsString(result2) must_== "1"
+      controller.invoked.get() must_== 1
+
+      // Test that the same headers are added
+      header(ETAG, result2) must_== header(ETAG, result1)
+      header(EXPIRES, result2) must_== header(EXPIRES, result1)
+
+      // Test that the values are in the right cache
+      app.injector.instanceOf[CacheApi].get("foo") must beNone
+      controller.isCached("foo-etag") must beTrue
+    }
+
+    "cache values using Application's Cached" in new WithApplication(
+      _.configure(configuration)
+    ) {
+      val invoked = new AtomicInteger()
+      val action = Cached(_ => "foo") {
+        (Action(Results.Ok("" + invoked.incrementAndGet())))
+      }
+      val result1 = action(FakeRequest()).run()
+      contentAsString(result1) must_== "1"
+      invoked.get() must_== 1
+      val result2 = action(FakeRequest()).run()
+      contentAsString(result2) must_== "1"
+
+      // Test that the same headers are added
+      header(ETAG, result2) must_== header(ETAG, result1)
+      header(EXPIRES, result2) must_== header(EXPIRES, result1)
+
+      invoked.get() must_== 1
+    }
+
+    "use etags for values" in new WithApplication(
+      _.configure(configuration)
+    ) {
+      val invoked = new AtomicInteger()
+      val action = Cached(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
+      val result1 = action(FakeRequest()).run()
+      status(result1) must_== 200
+      invoked.get() must_== 1
+      val etag = header(ETAG, result1)
+      etag must beSome(matching("""([wW]/)?"([^"]|\\")*"""")) //"""
+      val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> etag.get)).run()
+      status(result2) must_== NOT_MODIFIED
+      invoked.get() must_== 1
+    }
+
+    "support wildcard etags" in new WithApplication(
+      _.configure(configuration)
+    ) {
+      val invoked = new AtomicInteger()
+      val action = Cached(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
+      val result1 = action(FakeRequest()).run()
+      status(result1) must_== 200
+      invoked.get() must_== 1
+      val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> "*")).run()
+      status(result2) must_== NOT_MODIFIED
+      invoked.get() must_== 1
+    }
+
+    "work with etag cache misses" in new WithApplication(
+      _.configure(configuration)
+    ) {
+      val action = Cached(_.uri)(Action(Results.Ok))
+      val resultA = action(FakeRequest("GET", "/a")).run()
+      status(resultA) must_== 200
+      status(action(FakeRequest("GET", "/a").withHeaders(IF_NONE_MATCH -> "foo")).run) must_== 200
+      status(action(FakeRequest("GET", "/b").withHeaders(IF_NONE_MATCH -> header(ETAG, resultA).get)).run) must_== 200
+      status(action(FakeRequest("GET", "/c").withHeaders(IF_NONE_MATCH -> "*")).run) must_== 200
+    }
+  }
+
+  val dummyAction = Action { request =>
+    Results.Ok {
+      Random.nextInt().toString
+    }
+  }
+
+  val notFoundAction = Action { request =>
+    Results.NotFound(Random.nextInt().toString)
+  }
+
+  "Cached EssentialAction composition" should {
+    "cache infinite ok results" in new WithApplication(
+      _.configure(configuration)
+    ) {
+      val cacheOk = Cached.empty { x =>
+        x.uri
+      }.includeStatus(200)
+
+      val actionOk = cacheOk.build(dummyAction)
+      val actionNotFound = cacheOk.build(notFoundAction)
+
+      val res0 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
+      val res1 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
+
+      // println(("res0", header(EXPIRES, actionOk(FakeRequest("GET", "/a")).run)))
+
+      res0 must equalTo(res1)
+
+      val res2 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
+      val res3 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
+
+      res2 must not equalTo (res3)
+    }
+
+    "cache everything for infinite" in new WithApplication(
+      _.configure(configuration)
+    ) {
+      val cache = Cached.everything { x =>
+        x.uri
+      }
+
+      val actionOk = cache.build(dummyAction)
+      val actionNotFound = cache.build(notFoundAction)
+
+      val res0 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
+      val res1 = contentAsString(actionOk(FakeRequest("GET", "/a")).run)
+
+      res0 must equalTo(res1)
+
+      val res2 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
+      val res3 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
+
+      res2 must equalTo(res3)
+    }
+
+    "cache everything one hour" in new WithApplication(
+      _.configure(configuration)
+    ) {
+      val cache = Cached.everything(x => x.uri, 3600)
+
+      val actionOk = cache.build(dummyAction)
+      val actionNotFound = cache.build(notFoundAction)
+
+      val res0 = header(EXPIRES, actionOk(FakeRequest("GET", "/a")).run())
+      val res1 = header(EXPIRES, actionNotFound(FakeRequest("GET", "/b")).run())
+
+      def toDuration(header: String) = {
+        val now = DateTime.now().getMillis
+        val target = http.dateFormat.parseDateTime(header).getMillis
+        Duration(target - now, MILLISECONDS)
+      }
+
+      val beInOneHour = beBetween(
+        (Duration(1, HOURS) - Duration(10, SECONDS)).toMillis,
+        Duration(1, HOURS).toMillis)
+
+      res0.map(toDuration).map(_.toMillis) must beSome(beInOneHour)
+      res1.map(toDuration).map(_.toMillis) must beSome(beInOneHour)
+
+    }
+  }
+
+  "CacheApi" should {
+    "get items from cache" in new WithApplication(
+      _.configure(configuration)
+    ) {
+      val defaultCache = app.injector.instanceOf[CacheApi]
+      defaultCache.set("foo", "bar")
+      defaultCache.get[String]("foo") must beSome("bar")
+
+      defaultCache.set("int", 31)
+      defaultCache.get[Int]("int") must beSome(31)
+
+      defaultCache.set("long", 31l)
+      defaultCache.get[Long]("long") must beSome(31l)
+
+      defaultCache.set("double", 3.14)
+      defaultCache.get[Double]("double") must beSome(3.14)
+
+      defaultCache.set("boolean", true)
+      defaultCache.get[Boolean]("boolean") must beSome(true)
+
+      defaultCache.set("unit", ())
+      defaultCache.get[Unit]("unit") must beSome(())
+    }
+
+    "doesnt give items from cache with wrong type" in new WithApplication(
+      _.configure(configuration)
+    ) {
+      val defaultCache = app.injector.instanceOf[CacheApi]
+      defaultCache.set("foo", "bar")
+      defaultCache.set("int", 31)
+      defaultCache.set("long", 31l)
+      defaultCache.set("double", 3.14)
+      defaultCache.set("boolean", true)
+      defaultCache.set("unit", ())
+
+      defaultCache.get[Int]("foo") must beNone
+      defaultCache.get[Long]("foo") must beNone
+      defaultCache.get[Double]("foo") must beNone
+      defaultCache.get[Boolean]("foo") must beNone
+      defaultCache.get[String]("int") must beNone
+      defaultCache.get[Long]("int") must beNone
+      defaultCache.get[Double]("int") must beNone
+      defaultCache.get[Boolean]("int") must beNone
+      defaultCache.get[Unit]("foo") must beNone
+      defaultCache.get[Int]("unit") must beNone
+    }
+
+    "get items from the cache without giving the type" in new WithApplication(
+      _.configure(configuration)
+    ) {
+      val defaultCache = app.injector.instanceOf[CacheApi]
+      defaultCache.set("foo", "bar")
+      defaultCache.get("foo") must beSome("bar")
+      defaultCache.get[Any]("foo") must beSome("bar")
+
+      defaultCache.set("baz", false)
+      defaultCache.get("baz") must beSome(false)
+      defaultCache.get[Any]("baz") must beSome(false)
+
+      defaultCache.set("int", 31)
+      defaultCache.get("int") must beSome(31)
+      defaultCache.get[Any]("int") must beSome(31)
+
+      defaultCache.set("unit", ())
+      defaultCache.get("unit") must beSome(())
+      defaultCache.get[Any]("unit") must beSome(())
+    }
+  }
+
+  "JCacheModule" should {
+    "support binding multiple different caches" in new WithApplication(
+      _.configure(configuration).configure("play.cache.bindCaches" -> Seq("custom"))
+    ) {
+      val component = app.injector.instanceOf[SomeComponent]
+      val defaultCache = app.injector.instanceOf[CacheApi]
+      component.set("foo", "bar")
+      defaultCache.get("foo") must beNone
+      component.get("foo") must beSome("bar")
+    }
+  }
+
+}
+
+class SomeComponent @Inject()(@NamedCache("custom") cache: CacheApi) {
+  def get(key: String) = cache.get[String](key)
+  def set(key: String, value: String) = cache.set(key, value)
+}
+
+class CachedController @Inject() (cached: Cached) {
+  val invoked = new AtomicInteger()
+  val action = cached(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
+}
+
+class NamedCachedController @Inject() (
+                                        @NamedCache("custom") val cache: CacheApi,
+                                        @NamedCache("custom") val cached: Cached) {
+  val invoked = new AtomicInteger()
+  val action = cached(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
+  def isCached(key: String): Boolean = cache.get[String](key).isDefined
+}


### PR DESCRIPTION
This doesn't have to be merged, but I wanted some way to present this.  This is where I stand on implementation at the moment.  My thoughts on progressing this to support per-entry TTL where to do so by allowing for injection of a implementation specific strategy for cache value wrapping and unwrapping, and for customizing the configuration/creation paths.  That way the code as it stands would work fine for any 107 provider, but implementors would be able to inject strategies for providing a better experience.