### PR TITLE
Issue #6 Implement Ehcache wrapping

### DIFF
--- a/plugin/src/main/scala/org/ehcache/integrations/play/EhcacheJCacheWrapperModule.scala
+++ b/plugin/src/main/scala/org/ehcache/integrations/play/EhcacheJCacheWrapperModule.scala
@@ -16,6 +16,8 @@
 
 package org.ehcache.integrations.play
 
+import java.util.Collections.newSetFromMap
+import java.util.concurrent.ConcurrentHashMap
 import javax.cache.configuration.{Configuration => JCacheConfiguration}
 import javax.inject.{Inject, Provider, Singleton}
 
@@ -26,7 +28,6 @@ import org.ehcache.xml.XmlConfiguration
 import play.api.inject.Module
 import play.api.{Configuration, Environment}
 
-import scala.collection.mutable
 import scala.concurrent.duration.Duration
 
 /**
@@ -86,7 +87,7 @@ class NoOpValueWrapper extends ValueWrapper {
   */
 class EhcacheJCacheWrapper(xmlConfig: Option[XmlConfiguration]) extends JCacheWrapper {
 
-  val enhancedCaches = mutable.Set.empty[String]
+  val enhancedCaches = newSetFromMap[String](new ConcurrentHashMap[String, java.lang.Boolean]())
 
   def valueWrapper(name: String) = {
     enhancedCaches contains name match {

--- a/plugin/src/main/scala/org/ehcache/integrations/play/EhcacheJCacheWrapperModule.scala
+++ b/plugin/src/main/scala/org/ehcache/integrations/play/EhcacheJCacheWrapperModule.scala
@@ -105,7 +105,7 @@ class EhcacheJCacheWrapper(xmlConfig: Option[XmlConfiguration]) extends JCacheWr
       case null => generateMinimalConfiguration(name)
       case t if t.hasConfiguredExpiry =>
         val innerExpiry = t.build.getExpiry
-        fromEhcacheCacheConfiguration(t withExpiry new WrappedValueWithExpiryAndDelegateExpiration(innerExpiry))
+        fromEhcacheCacheConfiguration(t withExpiry new WrappedValueWithExpiryExpiration(innerExpiry))
       case t =>
         enhancedCaches add name
         fromEhcacheCacheConfiguration(t withExpiry new WrappedValueWithExpiryExpiration)

--- a/plugin/src/main/scala/org/ehcache/integrations/play/JCacheModule.scala
+++ b/plugin/src/main/scala/org/ehcache/integrations/play/JCacheModule.scala
@@ -173,14 +173,14 @@ class JCacheApi @Inject()(cache: Cache[String, Any], valueWrapper: ValueWrapper)
   }
 
   def get[T: ClassTag](key: String): Option[T] = {
-    return filter(cache.get(key))
+    filter(cache.get(key))
   }
 
   def getOrElse[A: ClassTag](key: String, expiration: Duration)(orElse: => A): A = {
     cache.invoke(key, new EntryProcessor[String, Any, A] {
       def process(entry: MutableEntry[String, Any], arguments: AnyRef*): A = {
         if (entry.exists()) {
-          filter(entry.getValue()).getOrElse({
+          filter(entry.getValue).getOrElse({
             entry.setValue(valueWrapper.wrapValue(orElse, expiration))
             orElse
           })

--- a/plugin/src/main/scala/org/ehcache/integrations/play/WrappedValueWithExpiry.scala
+++ b/plugin/src/main/scala/org/ehcache/integrations/play/WrappedValueWithExpiry.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.integrations.play
+
+import java.util.concurrent.TimeUnit
+
+import org.ehcache.ValueSupplier
+import org.ehcache.expiry.{Expiry, Duration => EhDuration}
+
+import scala.concurrent.duration.Duration
+
+/**
+  * WrappedValueWithExpiry
+  */
+case class WrappedValueWithExpiry(value: Any, expiration: Duration)
+
+/**
+  * WrappedValueWithExpiryExpiration
+  */
+class WrappedValueWithExpiryExpiration extends Expiry[String, Any] {
+  def getExpiryForAccess(key: String, value: ValueSupplier[_]): EhDuration = null
+
+  def getExpiryForCreation(key: String, value: Any): EhDuration = {
+   value match {
+     case (wrapped: WrappedValueWithExpiry) =>
+       wrapped.expiration match {
+         case Duration.Inf => EhDuration.INFINITE
+         case _ => EhDuration.of(wrapped.expiration.toMillis, TimeUnit.MILLISECONDS)
+       }
+     case _ => EhDuration.INFINITE
+   }
+  }
+
+  def getExpiryForUpdate(key: String, oldValue: ValueSupplier[_], newValue: Any): EhDuration = {
+    getExpiryForCreation(key, newValue)
+  }
+}

--- a/plugin/src/main/scala/org/ehcache/integrations/play/WrappedValueWithExpiry.scala
+++ b/plugin/src/main/scala/org/ehcache/integrations/play/WrappedValueWithExpiry.scala
@@ -17,36 +17,19 @@
 package org.ehcache.integrations.play
 
 import org.ehcache.ValueSupplier
-import org.ehcache.expiry.{Expiry, Duration => EhDuration}
+import org.ehcache.expiry.{Expirations, Expiry, Duration => EhDuration}
 
 import scala.concurrent.duration.Duration
 
-/**
-  * WrappedValueWithExpiry
-  */
 case class WrappedValueWithExpiry(value: Any, expiration: Duration) {
   require(expiration.isFinite())
 }
 
-/**
-  * WrappedValueWithExpiryExpiration
-  */
-class WrappedValueWithExpiryExpiration extends Expiry[String, Any] {
-  def getExpiryForAccess(key: String, value: ValueSupplier[_]): EhDuration = null
-
-  def getExpiryForCreation(key: String, value: Any): EhDuration = {
-    value match {
-      case WrappedValueWithExpiry(_, duration) => EhDuration.of(duration.length, duration.unit)
-      case _ => EhDuration.INFINITE
-    }
+class WrappedValueWithExpiryExpiration(delegate: Expiry[_ >: String, _ >: Any]) extends Expiry[String, Any] {
+  def this() = {
+    this(Expirations.noExpiration().asInstanceOf[Expiry[String, Any]])
   }
 
-  def getExpiryForUpdate(key: String, oldValue: ValueSupplier[_], newValue: Any): EhDuration = {
-    getExpiryForCreation(key, newValue)
-  }
-}
-
-class WrappedValueWithExpiryAndDelegateExpiration(delegate: Expiry[_ >: String, _ >: Any]) extends Expiry[String, Any] {
   def getExpiryForAccess(key: String, value: ValueSupplier[_]): EhDuration = delegate.getExpiryForAccess(key, value)
 
   def getExpiryForCreation(key: String, value: Any): EhDuration = {

--- a/plugin/src/test/resources/template-test-config.xml
+++ b/plugin/src/test/resources/template-test-config.xml
@@ -1,0 +1,43 @@
+<!--
+  ~ Copyright Terracotta, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<ehcache:config
+        xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xmlns:ehcache='http://www.ehcache.org/v3'>
+    <ehcache:cache-template name="template-no-expiry">
+        <ehcache:key-type>java.lang.String</ehcache:key-type>
+        <ehcache:value-type>java.lang.Object</ehcache:value-type>
+        <ehcache:heap>5</ehcache:heap>
+    </ehcache:cache-template>
+
+    <ehcache:cache-template name="template-expiry">
+        <ehcache:key-type>java.lang.String</ehcache:key-type>
+        <ehcache:value-type>java.lang.Object</ehcache:value-type>
+        <ehcache:expiry>
+            <ehcache:ttl unit="seconds">10</ehcache:ttl>
+        </ehcache:expiry>
+        <ehcache:heap>5</ehcache:heap>
+    </ehcache:cache-template>
+
+    <ehcache:cache-template name="template-wrap-expiry">
+        <ehcache:key-type>java.lang.String</ehcache:key-type>
+        <ehcache:value-type>java.lang.Object</ehcache:value-type>
+        <ehcache:expiry>
+            <ehcache:class>org.ehcache.integrations.play.WrappedValueWithExpiryExpiration</ehcache:class>
+        </ehcache:expiry>
+        <ehcache:heap>5</ehcache:heap>
+    </ehcache:cache-template>
+</ehcache:config>

--- a/plugin/src/test/scala/org/ehcache/integrations/play/EhcacheJCacheWrapperModuleSpec.scala
+++ b/plugin/src/test/scala/org/ehcache/integrations/play/EhcacheJCacheWrapperModuleSpec.scala
@@ -90,7 +90,7 @@ class EhcacheJCacheWrapperModuleSpec extends PlaySpecification {
       wrapper.wrapValue(testValue, Duration.create(100, TimeUnit.SECONDS)) must be equalTo testValue
     }
     "not unwrap value when it is WrappedValueWithExpiry" in {
-      val value = WrappedValueWithExpiry(testValue, Duration.Inf)
+      val value = WrappedValueWithExpiry(testValue, Duration.create(10, TimeUnit.SECONDS))
       wrapper.unwrapValue(value) must be equalTo value
     }
   }

--- a/plugin/src/test/scala/org/ehcache/integrations/play/EhcacheJCacheWrapperModuleSpec.scala
+++ b/plugin/src/test/scala/org/ehcache/integrations/play/EhcacheJCacheWrapperModuleSpec.scala
@@ -32,7 +32,7 @@ import scala.util.Try
   */
 class EhcacheJCacheWrapperModuleSpec extends PlaySpecification {
 
-  val xmlConfig = new XmlConfiguration(getClass().getResource("/template-test-config.xml"))
+  val xmlConfig = new XmlConfiguration(getClass.getResource("/template-test-config.xml"))
 
   "EhcacheJCacheWrapper" should {
     "enhance configuration always when no xml config specified" in {
@@ -40,7 +40,7 @@ class EhcacheJCacheWrapperModuleSpec extends PlaySpecification {
       val name = "name"
       val baseConfig: MutableConfiguration[String, Any] = new MutableConfiguration[String, Any]()
 
-      wrapper.enhanceConfiguration(name, baseConfig) must not beTheSameAs(baseConfig)
+      wrapper.enhanceConfiguration(name, baseConfig) must not beTheSameAs baseConfig
       wrapper.valueWrapper(name) must beAnInstanceOf[EhcacheValueWrapper]
     }
 

--- a/plugin/src/test/scala/org/ehcache/integrations/play/EhcacheJCacheWrapperModuleSpec.scala
+++ b/plugin/src/test/scala/org/ehcache/integrations/play/EhcacheJCacheWrapperModuleSpec.scala
@@ -16,6 +16,7 @@
 
 package org.ehcache.integrations.play
 
+import java.util.concurrent.TimeUnit
 import javax.cache.configuration.MutableConfiguration
 
 import org.ehcache.config.builders.CacheConfigurationBuilder
@@ -23,6 +24,7 @@ import org.ehcache.config.builders.CacheManagerBuilder.newCacheManagerBuilder
 import org.ehcache.xml.XmlConfiguration
 import play.api.test.PlaySpecification
 
+import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.Try
 
 /**
@@ -37,24 +39,59 @@ class EhcacheJCacheWrapperModuleSpec extends PlaySpecification {
       val wrapper = new EhcacheJCacheWrapper(None)
       val name = "name"
       val baseConfig: MutableConfiguration[String, Any] = new MutableConfiguration[String, Any]()
+
       wrapper.enhanceConfiguration(name, baseConfig) must not beTheSameAs(baseConfig)
       wrapper.valueWrapper(name) must beAnInstanceOf[EhcacheValueWrapper]
     }
 
     "enhance configuration when matching template has no expiry configured" in {
       val wrapper = new EhcacheJCacheWrapper(Some(xmlConfig))
-
       val name = "template-no-expiry"
       wrapper.enhanceConfiguration(name, new MutableConfiguration[String, Any]())
+
       wrapper.valueWrapper(name) must beAnInstanceOf[EhcacheValueWrapper]
     }
 
     "not enhance configuration when matching template has expiry configured" in {
       val wrapper = new EhcacheJCacheWrapper(Some(xmlConfig))
-
       val name = "template-expiry"
       wrapper.enhanceConfiguration(name, new MutableConfiguration[String, Any]())
+
       wrapper.valueWrapper(name) must beAnInstanceOf[NoOpValueWrapper]
+    }
+  }
+
+  "EhcacheValueWrapper" should {
+    val wrapper = new EhcacheValueWrapper
+    val testValue = "value"
+    val duration: FiniteDuration = Duration.create(100, TimeUnit.SECONDS)
+    "wrap value when expiration is not infinite" in {
+      wrapper.wrapValue(testValue, duration) must beEqualTo(WrappedValueWithExpiry(testValue, duration))
+
+    }
+    "not wrap value when expiration is infinite" in {
+      wrapper.wrapValue(testValue, Duration.Inf) must be equalTo testValue
+    }
+    "unwrap value when it is WrappedValueWithExpiry" in {
+      wrapper.unwrapValue(WrappedValueWithExpiry(testValue, duration)) must be equalTo testValue
+    }
+    "leave value untouched when it is not WrappedValueWithExpiry" in {
+      wrapper.unwrapValue(testValue) must be equalTo testValue
+    }
+  }
+
+  "NoOpValueWrapper" should {
+    val wrapper = new NoOpValueWrapper
+    val testValue = "value"
+    "not wrap value when expiration is infinite" in {
+      wrapper.wrapValue(testValue, Duration.Inf) must be equalTo testValue
+    }
+    "not wrap value when expiration is not infinite" in {
+      wrapper.wrapValue(testValue, Duration.create(100, TimeUnit.SECONDS)) must be equalTo testValue
+    }
+    "not unwrap value when it is WrappedValueWithExpiry" in {
+      val value = WrappedValueWithExpiry(testValue, Duration.Inf)
+      wrapper.unwrapValue(value) must be equalTo value
     }
   }
 
@@ -63,6 +100,7 @@ class EhcacheJCacheWrapperModuleSpec extends PlaySpecification {
       val manager = newCacheManagerBuilder().build(true)
       val template: CacheConfigurationBuilder[String, Any] = xmlConfig
               .newCacheConfigurationBuilderFromTemplate("template-wrap-expiry", classOf[String], classOf[Any])
+
       Try { manager.createCache("test", template)} must beASuccessfulTry
     }
   }

--- a/plugin/src/test/scala/org/ehcache/integrations/play/EhcacheJCacheWrapperModuleSpec.scala
+++ b/plugin/src/test/scala/org/ehcache/integrations/play/EhcacheJCacheWrapperModuleSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.integrations.play
+
+import javax.cache.configuration.MutableConfiguration
+
+import org.ehcache.config.builders.CacheConfigurationBuilder
+import org.ehcache.config.builders.CacheManagerBuilder.newCacheManagerBuilder
+import org.ehcache.xml.XmlConfiguration
+import play.api.test.PlaySpecification
+
+import scala.util.Try
+
+/**
+  * EhcacheJCacheWrapperModuleSpec
+  */
+class EhcacheJCacheWrapperModuleSpec extends PlaySpecification {
+
+  val xmlConfig = new XmlConfiguration(getClass().getResource("/template-test-config.xml"))
+
+  "EhcacheJCacheWrapper" should {
+    "enhance configuration always when no xml config specified" in {
+      val wrapper = new EhcacheJCacheWrapper(None)
+      val name = "name"
+      val baseConfig: MutableConfiguration[String, Any] = new MutableConfiguration[String, Any]()
+      wrapper.enhanceConfiguration(name, baseConfig) must not beTheSameAs(baseConfig)
+      wrapper.valueWrapper(name) must beAnInstanceOf[EhcacheValueWrapper]
+    }
+
+    "enhance configuration when matching template has no expiry configured" in {
+      val wrapper = new EhcacheJCacheWrapper(Some(xmlConfig))
+
+      val name = "template-no-expiry"
+      wrapper.enhanceConfiguration(name, new MutableConfiguration[String, Any]())
+      wrapper.valueWrapper(name) must beAnInstanceOf[EhcacheValueWrapper]
+    }
+
+    "not enhance configuration when matching template has expiry configured" in {
+      val wrapper = new EhcacheJCacheWrapper(Some(xmlConfig))
+
+      val name = "template-expiry"
+      wrapper.enhanceConfiguration(name, new MutableConfiguration[String, Any]())
+      wrapper.valueWrapper(name) must beAnInstanceOf[NoOpValueWrapper]
+    }
+  }
+
+  "Ehcache" should {
+    "be abe to use WrappedValueWithExpiryExpiration" in {
+      val manager = newCacheManagerBuilder().build(true)
+      val template: CacheConfigurationBuilder[String, Any] = xmlConfig
+              .newCacheConfigurationBuilderFromTemplate("template-wrap-expiry", classOf[String], classOf[Any])
+      Try { manager.createCache("test", template)} must beASuccessfulTry
+    }
+  }
+}

--- a/plugin/src/test/scala/org/ehcache/integrations/play/WrappedValueWithExpirySpec.scala
+++ b/plugin/src/test/scala/org/ehcache/integrations/play/WrappedValueWithExpirySpec.scala
@@ -39,31 +39,8 @@ class WrappedValueWithExpirySpec extends Specification with Mockito{
   }
 
   "WrappedValueWithExpiryExpiration" should {
-    val expiry = new WrappedValueWithExpiryExpiration
-    "always return null in getExpiryForAccess" in {
-      expiry.getExpiryForAccess("key", mock[ValueSupplier[_]]) must beNull
-    }
-    "default to Duration.INFINITE when value is not wrapped in getExpiryForCreation" in {
-      expiry.getExpiryForCreation("key", "value") must be equalTo EhDuration.INFINITE
-    }
-    "return configured expiration duration when value is wrapped in getExpiryForCreation" in {
-      val duration = Duration.create(10, TimeUnit.SECONDS)
-      val newValue = WrappedValueWithExpiry("value", duration)
-      expiry.getExpiryForCreation("key", newValue) must be equalTo EhDuration.of(10, TimeUnit.SECONDS)
-    }
-    "default to Duration.INFINITE when value is not wrapped in getExpiryForUpdate" in {
-      expiry.getExpiryForUpdate("key", mock[ValueSupplier[_]], "value") must be equalTo EhDuration.INFINITE
-    }
-    "return configured expiration duration when value is wrapped in getExpiryForUpdate" in {
-      val duration = Duration.create(10, TimeUnit.SECONDS)
-      val newValue = WrappedValueWithExpiry("value", duration)
-      expiry.getExpiryForUpdate("key", mock[ValueSupplier[_]], newValue) must be equalTo EhDuration.of(10, TimeUnit.SECONDS)
-    }
-  }
-
-  "WrappedValueWithExpiryAndDeleateExpiration" should {
     val mockedExpiry = mock[Expiry[String, Any]]
-    val expiry = new WrappedValueWithExpiryAndDelegateExpiration(mockedExpiry)
+    val expiry = new WrappedValueWithExpiryExpiration(mockedExpiry)
     "delegates in getExpiryForAccess" in {
       expiry.getExpiryForAccess("key", mock[ValueSupplier[_]])
       there was one(mockedExpiry).getExpiryForAccess(Matchers.eq("key"), any[ValueSupplier[_]])

--- a/plugin/src/test/scala/org/ehcache/integrations/play/WrappedValueWithExpirySpec.scala
+++ b/plugin/src/test/scala/org/ehcache/integrations/play/WrappedValueWithExpirySpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.integrations.play
+
+import java.util.concurrent.TimeUnit
+
+import org.ehcache.ValueSupplier
+import org.ehcache.expiry.{Expiry, Duration => EhDuration}
+import org.mockito.Matchers
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+
+import scala.concurrent.duration.Duration
+import scala.util.Try
+
+/**
+  * WrappedValueWithExpirySpec
+  */
+class WrappedValueWithExpirySpec extends Specification with Mockito{
+
+  "WrappedValueWithExpiry" should {
+    "fail to build if Duration.Inf is used" in {
+      Try { WrappedValueWithExpiry("value", Duration.Inf) } must beFailedTry
+    }
+  }
+
+  "WrappedValueWithExpiryExpiration" should {
+    val expiry = new WrappedValueWithExpiryExpiration
+    "always return null in getExpiryForAccess" in {
+      expiry.getExpiryForAccess("key", mock[ValueSupplier[_]]) must beNull
+    }
+    "default to Duration.INFINITE when value is not wrapped in getExpiryForCreation" in {
+      expiry.getExpiryForCreation("key", "value") must be equalTo EhDuration.INFINITE
+    }
+    "return configured expiration duration when value is wrapped in getExpiryForCreation" in {
+      val duration = Duration.create(10, TimeUnit.SECONDS)
+      val newValue = WrappedValueWithExpiry("value", duration)
+      expiry.getExpiryForCreation("key", newValue) must be equalTo EhDuration.of(10, TimeUnit.SECONDS)
+    }
+    "default to Duration.INFINITE when value is not wrapped in getExpiryForUpdate" in {
+      expiry.getExpiryForUpdate("key", mock[ValueSupplier[_]], "value") must be equalTo EhDuration.INFINITE
+    }
+    "return configured expiration duration when value is wrapped in getExpiryForUpdate" in {
+      val duration = Duration.create(10, TimeUnit.SECONDS)
+      val newValue = WrappedValueWithExpiry("value", duration)
+      expiry.getExpiryForUpdate("key", mock[ValueSupplier[_]], newValue) must be equalTo EhDuration.of(10, TimeUnit.SECONDS)
+    }
+  }
+
+  "WrappedValueWithExpiryAndDeleateExpiration" should {
+    val mockedExpiry = mock[Expiry[String, Any]]
+    val expiry = new WrappedValueWithExpiryAndDelegateExpiration(mockedExpiry)
+    "delegates in getExpiryForAccess" in {
+      expiry.getExpiryForAccess("key", mock[ValueSupplier[_]])
+      there was one(mockedExpiry).getExpiryForAccess(Matchers.eq("key"), any[ValueSupplier[_]])
+    }
+    "delegates when value is not wrapped in getExpiryForCreation" in {
+      expiry.getExpiryForCreation("key", "value")
+      there was one(mockedExpiry).getExpiryForCreation("key", "value")
+    }
+    "return configured expiration duration when value is wrapped in getExpiryForCreation" in {
+      val duration = Duration.create(10, TimeUnit.SECONDS)
+      val newValue = WrappedValueWithExpiry("value", duration)
+      expiry.getExpiryForCreation("key", newValue) must be equalTo EhDuration.of(10, TimeUnit.SECONDS)
+    }
+    "delegates when value is not wrapped in getExpiryForUpdate" in {
+      expiry.getExpiryForUpdate("key", mock[ValueSupplier[_]], "value")
+      there was one(mockedExpiry).getExpiryForUpdate(Matchers.eq("key"), any[ValueSupplier[_]], Matchers.eq("value"))
+    }
+    "return configured expiration duration when value is wrapped in getExpiryForUpdate" in {
+      val duration = Duration.create(10, TimeUnit.SECONDS)
+      val newValue = WrappedValueWithExpiry("value", duration)
+      expiry.getExpiryForUpdate("key", mock[ValueSupplier[_]], newValue) must be equalTo EhDuration.of(10, TimeUnit.SECONDS)
+    }
+  }
+}


### PR DESCRIPTION
* Already created caches are never considered.
* When no xml config exists or no template matches, will generate a
 minimal configuration and support value wrapping to enable per mapping
 expiry.
* When a matching template is found without expiry configured, enhance it
 to support value wrapping and per mapping expiry.
* When a matching template is found with expiry configured, per mapping
 expiry is not enabled.